### PR TITLE
Make game audio mixable with other app sound (MAD-17893)

### DIFF
--- a/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
@@ -483,7 +483,7 @@ namespace Audio
 
         AkPlatformInitSettings akPlatformInitSettings;
         AK::SoundEngine::GetDefaultPlatformInitSettings(akPlatformInitSettings);
-#if defined(CARBONATED)
+#if defined(CARBONATED) && defined(AZ_PLATFORM_IOS)
         // enable background music to play, mix game's audio with other sources
         akPlatformInitSettings.audioSession.eCategory = AkAudioSessionCategoryAmbient;  // was AkAudioSessionCategorySoloAmbient
         akPlatformInitSettings.audioSession.eCategoryOptions = AkAudioSessionCategoryOptionMixWithOthers;  // was AkAudioSessionCategoryOptionDuckOthers

--- a/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/AudioSystemImpl_wwise.cpp
@@ -483,7 +483,11 @@ namespace Audio
 
         AkPlatformInitSettings akPlatformInitSettings;
         AK::SoundEngine::GetDefaultPlatformInitSettings(akPlatformInitSettings);
-
+#if defined(CARBONATED)
+        // enable background music to play, mix game's audio with other sources
+        akPlatformInitSettings.audioSession.eCategory = AkAudioSessionCategoryAmbient;  // was AkAudioSessionCategorySoloAmbient
+        akPlatformInitSettings.audioSession.eCategoryOptions = AkAudioSessionCategoryOptionMixWithOthers;  // was AkAudioSessionCategoryOptionDuckOthers
+#endif
         Platform::SetupAkSoundEngine(akPlatformInitSettings);
 
         akResult = AK::SoundEngine::Init(&akInitSettings, &akPlatformInitSettings);


### PR DESCRIPTION
## What does this PR do?

Make game audio mixable with other app sound.
Before: on game launch or foreground other app sound turns of.
After: on game launch or foreground other app sound continues to play, mixed together.

## How was this PR tested?

Local build tests with sound cloud playing in foreground.
Also tested that game's sound is paused if the game goes background.
