### PR TITLE
Update Config_wwise.h with the real paths in the project

### DIFF
--- a/Gems/AudioEngineWwise/Code/Source/Engine/Config_wwise.h
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/Config_wwise.h
@@ -16,13 +16,20 @@
 
 namespace Audio::Wwise
 {
+#if defined(CARBONATED)    
+    static constexpr const char DefaultBanksPath[] = "Sounds/wwise/";
+#else
     static constexpr const char DefaultBanksPath[] = "sounds/wwise/";
+#endif
     static constexpr const char ExternalSourcesPath[] = "external";
     static constexpr const char ConfigFile[] = "wwise_config.json";
     static constexpr const char BankExtension[] = ".bnk";
     static constexpr const char MediaExtension[] = ".wem";
+#if defined(CARBONATED)    
+    static constexpr const char InitBank[] = "Init.bnk";
+#else
     static constexpr const char InitBank[] = "init.bnk";
-
+#endif
     //! Banks path that's set after reading the configuration settings.
     //! This might be different than the DefaultBanksPath.
     const AZStd::string_view GetBanksRootPath();


### PR DESCRIPTION
## What does this PR do?

The paths on the Linux should be 100% case match. The easiest way to change the source rather than rename sub-directories.

