### PR TITLE
Update CMakeLists.txt and audioenginewwise_builder_files.cmake so the AP and other tools can be compiled with Wwise

### DIFF
--- a/Gems/AudioEngineWwise/Code/CMakeLists.txt
+++ b/Gems/AudioEngineWwise/Code/CMakeLists.txt
@@ -174,9 +174,10 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
                 Legacy::CryCommon
             PRIVATE
                 Gem::${gem_name}.Builder.Private.Object
+#                Gem::${gem_name}.Private.Object       #  CARBONATED:  To avoid double include of 3rdParty::Wwise
     )
 
-#  CARBONATED:  Gem::${gem_name}.Private.Object was deleted in the previous ly_add_target {}. It was after Gem::${gem_name}.Builder.Private.Object
+
 
     ly_add_target(
         NAME ${gem_name}.Editor.Private.Object STATIC

--- a/Gems/AudioEngineWwise/Code/CMakeLists.txt
+++ b/Gems/AudioEngineWwise/Code/CMakeLists.txt
@@ -177,8 +177,6 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
 #                Gem::${gem_name}.Private.Object       #  CARBONATED:  To avoid double include of 3rdParty::Wwise
     )
 
-
-
     ly_add_target(
         NAME ${gem_name}.Editor.Private.Object STATIC
         NAMESPACE Gem

--- a/Gems/AudioEngineWwise/Code/CMakeLists.txt
+++ b/Gems/AudioEngineWwise/Code/CMakeLists.txt
@@ -176,6 +176,8 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::${gem_name}.Builder.Private.Object
     )
 
+#  CARBONATED:  Gem::${gem_name}.Private.Object was deleted in the previous ly_add_target {}. It was after Gem::${gem_name}.Builder.Private.Object
+
     ly_add_target(
         NAME ${gem_name}.Editor.Private.Object STATIC
         NAMESPACE Gem

--- a/Gems/AudioEngineWwise/Code/CMakeLists.txt
+++ b/Gems/AudioEngineWwise/Code/CMakeLists.txt
@@ -174,7 +174,6 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
                 Legacy::CryCommon
             PRIVATE
                 Gem::${gem_name}.Builder.Private.Object
-                Gem::${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/AudioEngineWwise/Code/audioenginewwise_builder_files.cmake
+++ b/Gems/AudioEngineWwise/Code/audioenginewwise_builder_files.cmake
@@ -15,7 +15,6 @@ set(FILES
     Source/Builder/WwiseBuilderComponent.h
     Source/Builder/WwiseBuilderWorker.cpp
     Source/Builder/WwiseBuilderWorker.h
-    Source/Engine/Config_wwise.cpp
+    Source/Engine/Config_wwise.cpp      # CARBONATED: added to support WWise on Linux in AssetProcessor, APB, etc...
 )
 
-# CARBONATED: The file Source/Engine/Config_wwise.cpp was added to support WWise on Linux in AssetProcessor, APB, etc...

--- a/Gems/AudioEngineWwise/Code/audioenginewwise_builder_files.cmake
+++ b/Gems/AudioEngineWwise/Code/audioenginewwise_builder_files.cmake
@@ -15,4 +15,5 @@ set(FILES
     Source/Builder/WwiseBuilderComponent.h
     Source/Builder/WwiseBuilderWorker.cpp
     Source/Builder/WwiseBuilderWorker.h
+    Source/Engine/Config_wwise.cpp
 )

--- a/Gems/AudioEngineWwise/Code/audioenginewwise_builder_files.cmake
+++ b/Gems/AudioEngineWwise/Code/audioenginewwise_builder_files.cmake
@@ -17,3 +17,5 @@ set(FILES
     Source/Builder/WwiseBuilderWorker.h
     Source/Engine/Config_wwise.cpp
 )
+
+# CARBONATED: The file Source/Engine/Config_wwise.cpp was added to support WWise on Linux in AssetProcessor, APB, etc...


### PR DESCRIPTION
## What does this PR do?

AssetProcessor and other tools can be compiled with Wwise on Linux

## How was this PR tested?

AssetProcessor, AssetProcessorBatch, AssetBundlerBatch are successfully compiled on Linux.
